### PR TITLE
Use Better Validator for the IG

### DIFF
--- a/shorthand/FhirDataEvaluatorIG/Makefile
+++ b/shorthand/FhirDataEvaluatorIG/Makefile
@@ -1,10 +1,11 @@
+VALIDATOR_VERSION=6.5.26
 RESOURCES_PATH ?= fsh-generated/resources/Measure-*.json
 
 build:
 	sushi build -s .
 
 validator_cli.jar:
-	wget -q https://github.com/hapifhir/org.hl7.fhir.validator-wrapper/releases/latest/download/validator_cli.jar
+	wget -q https://github.com/hapifhir/org.hl7.fhir.core/releases/download/$(VALIDATOR_VERSION)/validator_cli.jar
 
 validate: validator_cli.jar
 	java -jar validator_cli.jar -version 4.0.1 -level error -debug -ig fsh-generated/resources -ig hl7.fhir.us.cqfmeasures#4.0.0  $(RESOURCES_PATH)


### PR DESCRIPTION
Using the validator-wrapper repo to download the validator_cli.jar was no good idea. I changed that in Blaze in
https://github.com/samply/blaze/pull/2611. Also the version was set to latest, which isn't a good idea.